### PR TITLE
Removing Docker entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,3 @@ RUN CGO_ENABLED=0 go install -a -tags netgo -ldflags=-w
 
 FROM alpine:3.8
 COPY --from=build /go/bin/grpc-health-probe /bin/grpc_health_probe
-ENTRYPOINT [ "/bin/grpc_health_probe" ]


### PR DESCRIPTION
In the Kubernetes Init container we need to be able to leverage shell commands including the grpc_health_probe binary.